### PR TITLE
Fix env var flag binding

### DIFF
--- a/pkg/cmd/files/files.go
+++ b/pkg/cmd/files/files.go
@@ -5,6 +5,7 @@ import (
 	"github.com/debricked/cli/pkg/cmd/files/find"
 	"github.com/debricked/cli/pkg/file"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewFilesCmd(debClient *client.IDebClient) *cobra.Command {
@@ -12,6 +13,9 @@ func NewFilesCmd(debClient *client.IDebClient) *cobra.Command {
 		Use:   "files",
 		Short: "Analyze files",
 		Long:  "Analyze files",
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.Flags())
+		},
 	}
 
 	f, _ := file.NewFinder(*debClient)

--- a/pkg/cmd/files/find/find.go
+++ b/pkg/cmd/files/find/find.go
@@ -15,7 +15,7 @@ var jsonPrint bool
 var lockfileOnly bool
 
 const (
-	ExclusionsFlag   = "exclusions"
+	ExclusionFlag    = "exclusion"
 	JsonFlag         = "json"
 	LockfileOnlyFlag = "lockfile"
 )
@@ -27,9 +27,12 @@ func NewFindCmd(finder file.IFinder) *cobra.Command {
 		Long: `Find all dependency files in inputted path. Related files are grouped together. 
 For example ` + "`package.json`" + ` with ` + "`package-lock.json`.",
 		Args: validateArgs,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.PersistentFlags())
+		},
 		RunE: RunE(finder),
 	}
-	cmd.Flags().StringArrayVarP(&exclusions, ExclusionsFlag, "e", exclusions, `The following terms are supported to exclude paths:
+	cmd.Flags().StringArrayVarP(&exclusions, ExclusionFlag, "e", exclusions, `The following terms are supported to exclude paths:
 Special Terms | Meaning
 ------------- | -------
 "*"           | matches any sequence of non-Separator characters 
@@ -42,6 +45,7 @@ Examples:
 $ debricked files find . -e "*/**.lock" -e "**/node_modules/**" 
 $ debricked files find . -e "*\**.exe" -e "**\node_modules\**" 
 `)
+
 	cmd.Flags().BoolVarP(&jsonPrint, JsonFlag, "j", false, `Print files in JSON format
 Format:
 [
@@ -54,8 +58,8 @@ Format:
 ]
 `)
 	cmd.Flags().BoolVarP(&lockfileOnly, LockfileOnlyFlag, "l", false, "If set, only lock files are found")
-	_ = viper.BindPFlags(cmd.Flags())
-	viper.MustBindEnv(ExclusionsFlag)
+
+	viper.MustBindEnv(ExclusionFlag)
 	viper.MustBindEnv(JsonFlag)
 	viper.MustBindEnv(LockfileOnlyFlag)
 
@@ -65,7 +69,7 @@ Format:
 func RunE(f file.IFinder) func(_ *cobra.Command, args []string) error {
 	return func(_ *cobra.Command, args []string) error {
 		directoryPath := args[0]
-		fileGroups, err := f.GetGroups(directoryPath, viper.GetStringSlice(ExclusionsFlag), viper.GetBool(LockfileOnlyFlag))
+		fileGroups, err := f.GetGroups(directoryPath, viper.GetStringSlice(ExclusionFlag), viper.GetBool(LockfileOnlyFlag))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/files/find/find_test.go
+++ b/pkg/cmd/files/find/find_test.go
@@ -33,7 +33,7 @@ func TestNewFindCmd(t *testing.T) {
 	}
 
 	var flagKeys = []string{
-		ExclusionsFlag,
+		ExclusionFlag,
 		JsonFlag,
 	}
 	viperKeys := viper.AllKeys()
@@ -56,6 +56,19 @@ func TestRunE(t *testing.T) {
 	groups := file.Groups{}
 	groups.Add(file.Group{})
 	f.SetGetGroupsReturnMock(groups, nil)
+	runE := RunE(f)
+	err := runE(nil, []string{"."})
+	if err != nil {
+		t.Fatal("failed to assert that no error occurred. Error:", err)
+	}
+}
+
+func TestRunENoFiles(t *testing.T) {
+	f := testdata.NewFinderMock()
+	groups := file.Groups{}
+	groups.Add(file.Group{})
+	f.SetGetGroupsReturnMock(groups, nil)
+	exclusions = []string{}
 	runE := RunE(f)
 	err := runE(nil, []string{"."})
 	if err != nil {

--- a/pkg/cmd/report/license/license.go
+++ b/pkg/cmd/report/license/license.go
@@ -25,24 +25,23 @@ func NewLicenseCmd(reporter report.IReporter) *cobra.Command {
 		Long: `Generate license report from a commit hash. 
 This is a premium feature. Please visit https://debricked.com/pricing/ for more info.
 The finished report will be sent to the specified email address.`,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.Flags())
+		},
 		RunE: RunE(reporter),
 	}
 
 	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the report will be sent to")
-	_ = cmd.MarkFlagRequired(EmailFlag)
 	viper.MustBindEnv(EmailFlag)
 
 	cmd.Flags().StringVarP(&commitHash, CommitFlag, "c", "", "commit hash")
-	_ = cmd.MarkFlagRequired(CommitFlag)
 	viper.MustBindEnv(CommitFlag)
-
-	_ = viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }
 
 func RunE(r report.IReporter) func(_ *cobra.Command, args []string) error {
-	return func(_ *cobra.Command, _ []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
 		orderArgs := license.OrderArgs{
 			Email:      viper.GetString(EmailFlag),
 			CommitHash: viper.GetString(CommitFlag),

--- a/pkg/cmd/report/report.go
+++ b/pkg/cmd/report/report.go
@@ -7,6 +7,7 @@ import (
 	licenseReport "github.com/debricked/cli/pkg/report/license"
 	vulnerabilityReport "github.com/debricked/cli/pkg/report/vulnerability"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewReportCmd(debClient *client.IDebClient) *cobra.Command {
@@ -15,6 +16,9 @@ func NewReportCmd(debClient *client.IDebClient) *cobra.Command {
 		Short: "Generate reports",
 		Long: `Generate reports.
 This is a premium feature. Please visit https://debricked.com/pricing/ for more info.`,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.Flags())
+		},
 	}
 
 	lReporter := licenseReport.Reporter{DebClient: *debClient}

--- a/pkg/cmd/report/vulnerability/vulnerability.go
+++ b/pkg/cmd/report/vulnerability/vulnerability.go
@@ -21,14 +21,15 @@ func NewVulnerabilityCmd(reporter report.IReporter) *cobra.Command {
 		Long: `Generate vulnerability report for all your repositories. 
 This is a premium feature. Please visit https://debricked.com/pricing/ for more info.
 The finished report will be sent to the specified email address.`,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.Flags())
+		},
 		RunE: RunE(reporter),
 	}
 
 	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the report will be sent to")
 	_ = cmd.MarkFlagRequired(EmailFlag)
 	viper.MustBindEnv(EmailFlag)
-
-	_ = viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,9 @@ func NewRootCmd() *cobra.Command {
 		Short: "Debricked CLI - Keep track of your dependencies!",
 		Long: `A fast and flexible software composition analysis CLI tool, given to you by Debricked.
 Complete documentation is available at https://debricked.com/docs/integrations/cli.html#debricked-cli`,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.PersistentFlags())
+		},
 	}
 	viper.SetEnvPrefix("DEBRICKED")
 	viper.MustBindEnv(AccessTokenFlag)
@@ -30,12 +33,11 @@ Complete documentation is available at https://debricked.com/docs/integrations/c
 		`Debricked access token. 
 Read more: https://debricked.com/docs/administration/access-tokens.html`,
 	)
-	_ = viper.BindPFlags(rootCmd.PersistentFlags())
 
 	var debClient client.IDebClient = client.NewDebClient(&accessToken)
 	rootCmd.AddCommand(report.NewReportCmd(&debClient))
-	rootCmd.AddCommand(scan.NewScanCmd(&debClient))
 	rootCmd.AddCommand(files.NewFilesCmd(&debClient))
+	rootCmd.AddCommand(scan.NewScanCmd(&debClient))
 
 	return rootCmd
 }

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -27,7 +27,7 @@ const (
 	CommitAuthorFlag  = "author"
 	RepositoryUrlFlag = "repository-url"
 	IntegrationFlag   = "integration"
-	ExclusionsFlag    = "exclusions"
+	ExclusionFlag     = "exclusion"
 )
 
 var scanCmdError error
@@ -45,6 +45,9 @@ func NewScanCmd(c *client.IDebClient) *cobra.Command {
 		Long: `All supported dependency files will be scanned and analysed.
 If the given path contains a git repository all flags but "integration" will be resolved. Otherwise they have to specified.`,
 		Args: ValidateArgs,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlags(cmd.Flags())
+		},
 		RunE: RunE(&s),
 	}
 	cmd.Flags().StringVarP(&repositoryName, RepositoryFlag, "r", "", "repository name")
@@ -53,7 +56,7 @@ If the given path contains a git repository all flags but "integration" will be 
 	cmd.Flags().StringVarP(&commitAuthor, CommitAuthorFlag, "a", "", "commit author")
 	cmd.Flags().StringVarP(&repositoryUrl, RepositoryUrlFlag, "u", "", "repository URL")
 	cmd.Flags().StringVarP(&integrationName, IntegrationFlag, "i", "CLI", `name of integration used to trigger scan. For example "GitHub Actions"`)
-	cmd.Flags().StringArrayVarP(&exclusions, ExclusionsFlag, "e", exclusions, `The following terms are supported to exclude paths:
+	cmd.Flags().StringArrayVarP(&exclusions, ExclusionFlag, "e", exclusions, `The following terms are supported to exclude paths:
 Special Terms | Meaning
 ------------- | -------
 "*"           | matches any sequence of non-Separator characters 
@@ -72,9 +75,6 @@ $ debricked scan . -e "*\**.exe" -e "**\node_modules\**"
 	viper.MustBindEnv(CommitAuthorFlag)
 	viper.MustBindEnv(RepositoryUrlFlag)
 	viper.MustBindEnv(IntegrationFlag)
-	viper.MustBindEnv(ExclusionsFlag)
-
-	_ = viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }
@@ -84,7 +84,7 @@ func RunE(s *scan.IScanner) func(_ *cobra.Command, args []string) error {
 		directoryPath := args[0]
 		options := scan.DebrickedOptions{
 			DirectoryPath:   directoryPath,
-			Exclusions:      viper.GetStringSlice(ExclusionsFlag),
+			Exclusions:      viper.GetStringSlice(ExclusionFlag),
 			RepositoryName:  viper.GetString(RepositoryFlag),
 			CommitName:      viper.GetString(CommitFlag),
 			BranchName:      viper.GetString(BranchFlag),

--- a/pkg/scan/scanner_test.go
+++ b/pkg/scan/scanner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/debricked/cli/pkg/ci/travis"
 	"github.com/debricked/cli/pkg/client"
 	"github.com/debricked/cli/pkg/git"
+	"github.com/debricked/cli/pkg/upload"
 	"strings"
 	"testing"
 )
@@ -108,6 +109,38 @@ func TestScanFailingMetaObject(t *testing.T) {
 	err = scanner.Scan(opts)
 	if err != git.CommitNameError {
 		t.Error("failed to assert that CommitNameError occurred")
+	}
+}
+
+func TestScanFailingNoFiles(t *testing.T) {
+	var debClient client.IDebClient
+	debClient = client.NewDebClient(nil)
+	var ciService ci.IService
+	ciService = ci.NewService([]ci.ICi{
+		argo.Ci{},
+		azure.Ci{},
+		bitbucket.Ci{},
+		buildkite.Ci{},
+		circleci.Ci{},
+		//github.Ci{}, Since GitHub actions is used, this ICi is ignored
+		gitlab.Ci{},
+		travis.Ci{},
+	})
+	scanner, _ := NewDebrickedScanner(&debClient, ciService)
+	directoryPath := "."
+	opts := DebrickedOptions{
+		DirectoryPath:   directoryPath,
+		Exclusions:      []string{"testdata/**"},
+		RepositoryName:  "name",
+		CommitName:      "commit",
+		BranchName:      "branch",
+		CommitAuthor:    "",
+		RepositoryUrl:   "",
+		IntegrationName: "",
+	}
+	err := scanner.Scan(opts)
+	if err != upload.NoFilesErr {
+		t.Error("failed to assert that error NoFilesErr occurred")
 	}
 }
 

--- a/pkg/upload/batch.go
+++ b/pkg/upload/batch.go
@@ -20,6 +20,10 @@ import (
 	"time"
 )
 
+var (
+	NoFilesErr = errors.New("failed to find dependency files")
+)
+
 type uploadBatch struct {
 	client          *client.IDebClient
 	fileGroups      file.Groups
@@ -116,7 +120,7 @@ func (uploadBatch *uploadBatch) uploadFile(filePath string) error {
 // conclude send the conclusion request to Debricked
 func (uploadBatch *uploadBatch) conclude() error {
 	if uploadBatch.ciUploadId == 0 {
-		return errors.New("failed to find dependency files")
+		return NoFilesErr
 	}
 	body, err := json.Marshal(uploadConclusion{
 		CiUploadId:      strconv.Itoa(uploadBatch.ciUploadId),


### PR DESCRIPTION
All  env var bindings had to be moved to the preRun function on every command as a workaround for: https://github.com/spf13/viper/issues/233