### PR TITLE
Update docs to indicate Go >= 1.20 required now.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Feel free to reach out to any of the maintainers or other community members if y
 
 Requirements
 
-    Go version 1.17 or higher
+    Go version 1.20 or higher
 
 ### If you have questions
 


### PR DESCRIPTION
As the title describes, Go version 1.18 (my old version) no longer worked with running `make install` and told me to upgrade to 1.20. After upgrading, it now works.

The exact issue I had:

```
make install
bash scripts/install.sh
# [github.com/debricked/cli/internal/file](http://github.com/debricked/cli/internal/file)
internal/file/group.go:55:28: undefined: strings.CutSuffix
internal/file/group.go:69:33: undefined: strings.CutSuffix
note: module requires Go 1.20
make: *** [Makefile:3: install] Error 2
```