### PR TITLE
Sign releases using GPG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,19 @@ jobs:
         with:
           go-version: '>=1.20'
           cache: true
+      - name: Import GPG signing key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on the needs.
-      - uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,10 @@ snapshot:
 changelog:
   sort: asc
 
+signs:
+  - artifacts: checksum
+    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+
 nfpms:
   - maintainer: viktigpetterr <viktor.grasljunga@gmail.com>
     description: Debricked's own command line interface.


### PR DESCRIPTION
Uses built-in support for creating signed checksum files with Goreleaser. Based on this official README: https://github.com/goreleaser/goreleaser-action#signing