### PR TITLE
Use dry run for pip instead of actually installing packages for speed…

### DIFF
--- a/internal/resolution/pm/pip/cmd_factory.go
+++ b/internal/resolution/pm/pip/cmd_factory.go
@@ -58,7 +58,7 @@ func (cmdf CmdFactory) MakeInstallCmd(command string, file string) (*exec.Cmd, e
 
 	return &exec.Cmd{
 		Path: path,
-		Args: []string{command, "install", "-r", file},
+		Args: []string{command, "install", "-r", file, "--dry-run"},
 	}, err
 }
 


### PR DESCRIPTION
… up and increased compatibility

Suggested implementation of #86 