### PR TITLE
Fingerprint improvements

### DIFF
--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -41,6 +41,7 @@ var EXCLUDED_FILE_ENDINGS = []string{"-doc", "changelog", "config", "copying", "
 var EXCLUDED_FILES = []string{
 	"gradlew", "gradlew.bat", "mvnw", "mvnw.cmd", "gradle-wrapper.jar", "maven-wrapper.jar",
 	"thumbs.db", "babel.config.js", "license.txt", "license.md", "copying.lib", "makefile",
+	"[content_types].xml",
 }
 
 var FILES_TO_UNPACK = []string{".jar", ".nupkg", ".war"}


### PR DESCRIPTION
It is common in nuget to auto-generate a "[Content_Types].xml" file with some information. This file does not help to uniquely identify a package, and there can be quite some overlap between different packages. This results in false positives in our fingerprinting, and I'd like to exclude that fille. 