### PR TITLE
Update various actions to their latest versions to get rid of Node 16…

### DIFF
--- a/.github/workflows/codescene.yml
+++ b/.github/workflows/codescene.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: empear/codescene-ci-cd:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run delta analysis

--- a/.github/workflows/debricked.yml
+++ b/.github/workflows/debricked.yml
@@ -11,18 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Pull Supported Formats
         run: |
           cd cmd/debricked

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.20'
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           git config --global core.autocrlf input
           git config --global core.eol lf
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -30,15 +30,6 @@ jobs:
         run: |
           npm install --global bower
           bower -v
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ matrix.os }}-go
 
       - name: Pull Supported Formats
         run: |
@@ -54,7 +45,7 @@ jobs:
           TEST_COVERAGE_THRESHOLD: 90
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: coverage.html
@@ -79,21 +70,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ matrix.os }}-go
 
       - name: Pull Supported Formats
         run: |
@@ -104,7 +86,7 @@ jobs:
         run: go build -v ./...
 
       - name: Set up Java ${{matrix.java}}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{matrix.java}}
           distribution: 'temurin'
@@ -122,7 +104,7 @@ jobs:
       matrix:
         docker-os: ['alpine', 'debian']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Pull from debian and re-tag to match cache
       - name: Pull Image; Debian
@@ -151,8 +133,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
       - name: Pull Supported Formats
@@ -160,6 +142,6 @@ jobs:
           cd cmd/debricked
           go generate -v -x
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.52

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p align="center">
-  <a href="#"/>
   <p align="center">
-    <img width="150" height="150" src="/assets/CLI_logo_1024.png" alt="Logo">
+    <img width="150" height="150" src="./assets/CLI_logo_1024.png" alt="Logo">
     <h1 align="center"><b>Debricked CLI</b></h1>
     <p align="center">
     Safety through commandline.

--- a/examples/templates/GitHub/debricked-non-docker.yml
+++ b/examples/templates/GitHub/debricked-non-docker.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: debricked/actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: debricked/actions/cache@v4
       - uses: debricked/actions/scan-non-docker@v3
         env:
           DEBRICKED_TOKEN: ${{ secrets.DEBRICKED_TOKEN }}

--- a/examples/templates/GitHub/debricked.yml
+++ b/examples/templates/GitHub/debricked.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: debricked/actions@v3
         env:
           DEBRICKED_TOKEN: ${{ secrets.DEBRICKED_TOKEN }}


### PR DESCRIPTION
… deprecation and remove caching of Go dependencies as it is now built into actions/setup-go