### PR TITLE
Fix fingerprint file exclusion bug

### DIFF
--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -80,7 +80,8 @@ func isExcludedByExtension(filename string) bool {
 }
 
 func isExcludedByFilename(filename string) bool {
-	filenameLower := strings.ToLower(filename)
+	baseFilename := filepath.Base(filename)
+	filenameLower := strings.ToLower(baseFilename)
 	for _, file := range EXCLUDED_FILES {
 		if filenameLower == file {
 			return true

--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -61,17 +61,17 @@ const (
 	OutputFileNameFingerprints = "debricked.fingerprints.txt"
 )
 
-func isExcludedFile(filename string) bool {
+func isExcludedFile(path string) bool {
 
-	return isExcludedByExtension(filename) ||
-		isExcludedByFilename(filename) ||
-		isExcludedByEnding(filename)
+	return isExcludedByExtension(path) ||
+		isExcludedByFilename(path) ||
+		isExcludedByEnding(path)
 }
 
-func isExcludedByExtension(filename string) bool {
-	filenameLower := strings.ToLower(filename)
+func isExcludedByExtension(path string) bool {
+	pathLower := strings.ToLower(path)
 	for _, format := range EXCLUDED_EXT {
-		if filepath.Ext(filenameLower) == format {
+		if filepath.Ext(pathLower) == format {
 			return true
 		}
 	}
@@ -79,9 +79,9 @@ func isExcludedByExtension(filename string) bool {
 	return false
 }
 
-func isExcludedByFilename(filename string) bool {
-	baseFilename := filepath.Base(filename)
-	filenameLower := strings.ToLower(baseFilename)
+func isExcludedByFilename(path string) bool {
+	filename := filepath.Base(path)
+	filenameLower := strings.ToLower(filename)
 	for _, file := range EXCLUDED_FILES {
 		if filenameLower == file {
 			return true
@@ -91,10 +91,10 @@ func isExcludedByFilename(filename string) bool {
 	return false
 }
 
-func isExcludedByEnding(filename string) bool {
-	filenameLower := strings.ToLower(filename)
+func isExcludedByEnding(path string) bool {
+	pathLower := strings.ToLower(path)
 	for _, ending := range EXCLUDED_FILE_ENDINGS {
-		if strings.HasSuffix(filenameLower, ending) {
+		if strings.HasSuffix(pathLower, ending) {
 			return true
 		}
 	}

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -21,9 +21,11 @@ func TestIsExcludedFile(t *testing.T) {
 	}
 
 	// Test excluded files
-	excludedFiles := []string{"LICENSE", "README.md", "Makefile"}
-	for _, file := range excludedFiles {
-		assert.True(t, isExcludedFile(file), "Expected %q to be excluded", file)
+	excludedFiles := []string{"LICENSE", "README.md", "Makefile", "mvnw", "[content_types].xml"}
+	for _, filename := range excludedFiles {
+		assert.True(t, isExcludedFile(filename), "Expected %q to be excluded", filename)
+		filepath := "foo/bar/" + filename
+		assert.True(t, isExcludedFile(filepath), "Expected %q to be excluded", filepath)
 	}
 
 	// Test excluded file endings
@@ -389,7 +391,7 @@ func TestInMemFingerprintingCompressedContent(t *testing.T) {
 		{
 			name:        "Nupkg",
 			path:        "testdata/archive/nupkg",
-			expected:    22,
+			expected:    21,
 			suffix:      "newtonsoft.json.13.0.3.nupkg",
 			shouldUnzip: true,
 		},


### PR DESCRIPTION
Compare only filename element of path when filtering out files for fingerprinting.