### PR TITLE
Fix issue with tar.gz file fingerprinting

### DIFF
--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -332,7 +332,7 @@ func isZipFile(filename string) bool {
 
 func isTarGZipFile(filename string) bool {
 	for _, file := range TAR_GZIP_FILE_ENDINGS {
-		if filepath.Ext(filename) == file {
+		if strings.HasSuffix(filename, file) {
 			return true
 		}
 	}

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -362,6 +362,11 @@ func TestIsTarGZip(t *testing.T) {
 			filename: "deep/folder/test.tgz",
 			want:     true,
 		},
+		{
+			name:     "tar.gz",
+			filename: "deep/folder/python-dotenv-1.0.0.tar.gz",
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Found a bug where we didn't unpack *.tar.gz files properly as the filepath.Ext didn't properly capture it. 