### PR TITLE
Print detailed url also when queue time is long

### DIFF
--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -117,8 +117,9 @@ func (dScanner *DebrickedScanner) Scan(o IOptions) error {
 		return dScanner.handleScanError(err, dOptions.PassOnTimeOut)
 	}
 
-	if result == nil {
+	if result.LongQueue {
 		fmt.Println("Progress polling terminated due to long scan times. Please try again later")
+		fmt.Printf("For full details, visit: %s\n\n", color.BlueString(result.DetailsUrl))
 
 		return nil
 	}

--- a/internal/upload/batch.go
+++ b/internal/upload/batch.go
@@ -224,17 +224,22 @@ func (uploadBatch *uploadBatch) wait() (*UploadResult, error) {
 		if err != nil {
 			return nil, err
 		}
+		status, err := newUploadStatus(res)
+		if err != nil {
+			return nil, err
+		}
 		if res.StatusCode == http.StatusCreated {
 			err := bar.Finish()
 			if err != nil {
 				return resultStatus, err
 			}
 
+			resultStatus = &UploadResult{
+				DetailsUrl: status.DetailsUrl,
+				LongQueue:  true,
+			}
+
 			return resultStatus, PollingTerminatedErr
-		}
-		status, err := newUploadStatus(res)
-		if err != nil {
-			return nil, err
 		}
 		err = bar.Set(status.Progress)
 		if err != nil {

--- a/internal/upload/batch_test.go
+++ b/internal/upload/batch_test.go
@@ -77,7 +77,7 @@ func TestWaitWithPollingTerminatedError(t *testing.T) {
 
 	uploadResult, err := batch.wait()
 
-	assert.Nil(t, uploadResult)
+	assert.True(t, uploadResult.LongQueue)
 	assert.ErrorIs(t, err, PollingTerminatedErr)
 }
 

--- a/internal/upload/result.go
+++ b/internal/upload/result.go
@@ -10,6 +10,7 @@ type UploadResult struct {
 	AutomationsAction              string            `json:"automationsAction"`
 	AutomationRules                []automation.Rule `json:"automationRules"`
 	DetailsUrl                     string            `json:"detailsUrl"`
+	LongQueue                      bool
 }
 
 func newUploadResult(status *uploadStatus) *UploadResult {
@@ -19,5 +20,6 @@ func newUploadResult(status *uploadStatus) *UploadResult {
 		status.AutomationsAction,
 		status.AutomationRules,
 		status.DetailsUrl,
+		false,
 	}
 }

--- a/internal/upload/uploader_test.go
+++ b/internal/upload/uploader_test.go
@@ -85,7 +85,7 @@ func TestUploadPollingError(t *testing.T) {
 	result, err := uploader.Upload(uploaderOptions)
 
 	assert.NoError(t, err)
-	assert.Nil(t, result)
+	assert.True(t, result.LongQueue)
 }
 
 type debClientMock struct{}


### PR DESCRIPTION
The URL is useful for users to take a look at the results later on.

Expected result with this pull request:

![image](https://github.com/user-attachments/assets/08847d61-84f4-4aec-8c9d-c95a5225f12b)

