### PR TITLE
Improve nuget resolution: Availability error

### DIFF
--- a/internal/resolution/pm/nuget/job.go
+++ b/internal/resolution/pm/nuget/job.go
@@ -207,6 +207,7 @@ func (j *Job) getNoInternetErrorDocumentation(matches [][]string) string {
 			"Registry",
 			"\"" + registry + "\"",
 			"is not available at the moment.",
-			"There might be a trouble with your network connection.",
+			"There might be a trouble with your network connection,",
+			"or this could be an authentication issue if this is a private registry.",
 		}, " ")
 }

--- a/internal/resolution/pm/nuget/job_test.go
+++ b/internal/resolution/pm/nuget/job_test.go
@@ -115,7 +115,7 @@ func TestRunInstallCmdErr(t *testing.T) {
 		{
 			name:  "No internet connection",
 			error: "Unable to load the service index for source https://api.nuget.org/v3/index.json.\nAn error occurred while sending the request. \nThe remote name could not be resolved: 'api.nuget.org'",
-			doc:   "Registry \"https://api.nuget.org/v3/index.json\" is not available at the moment. There might be a trouble with your network connection.",
+			doc:   "Registry \"https://api.nuget.org/v3/index.json\" is not available at the moment. There might be a trouble with your network connection, or this could be an authentication issue if this is a private registry.",
 		},
 	}
 


### PR DESCRIPTION
Adds mention of private registry authentication as possible cause for registry availability error.