### PR TITLE
File fingerprinting c/c++

### DIFF
--- a/internal/scan/scanner.go
+++ b/internal/scan/scanner.go
@@ -71,6 +71,7 @@ type DebrickedOptions struct {
 	CallGraphGenerateTimeout    int
 	MinFingerprintContentLength int
 	TagCommitAsRelease          bool
+	Experimental                bool
 }
 
 func NewDebrickedScanner(
@@ -282,6 +283,7 @@ func (dScanner *DebrickedScanner) scan(options DebrickedOptions, gitMetaObject g
 		VersionHint:            options.VersionHint,
 		DebrickedConfig:        dScanner.getDebrickedConfig(options.Path, options.Exclusions, options.Inclusions),
 		TagCommitAsRelease:     options.TagCommitAsRelease,
+		Experimental:           options.Experimental,
 	}
 	result, err := (*dScanner.uploader).Upload(uploaderOptions)
 	if err != nil {

--- a/internal/upload/batch.go
+++ b/internal/upload/batch.go
@@ -42,12 +42,13 @@ type uploadBatch struct {
 	versionHint        bool
 	debrickedConfig    *DebrickedConfig // JSON Config
 	tagCommitAsRelease bool
+	experimental       bool
 }
 
 func newUploadBatch(
 	client *client.IDebClient, fileGroups file.Groups, gitMetaObject *git.MetaObject,
-	integrationName string, callGraphTimeout int, versionHint bool, debrickedConfig *DebrickedConfig,
-	tagCommitAsRelease bool,
+	integrationName string, callGraphTimeout int, versionHint bool,
+	debrickedConfig *DebrickedConfig, tagCommitAsRelease bool, experimental bool,
 ) *uploadBatch {
 	return &uploadBatch{
 		client:             client,
@@ -59,6 +60,7 @@ func newUploadBatch(
 		versionHint:        versionHint,
 		debrickedConfig:    debrickedConfig,
 		tagCommitAsRelease: tagCommitAsRelease,
+		experimental:       experimental,
 	}
 }
 
@@ -187,6 +189,7 @@ func (uploadBatch *uploadBatch) initAnalysis() error {
 		DebrickedConfig:      uploadBatch.debrickedConfig,
 		DebrickedIntegration: "cli",
 		TagCommitAsRelease:   uploadBatch.tagCommitAsRelease,
+		Experimental:         uploadBatch.experimental,
 	})
 
 	if err != nil {
@@ -332,6 +335,7 @@ type uploadFinish struct {
 	VersionHint          bool             `json:"versionHint"`
 	DebrickedConfig      *DebrickedConfig `json:"debrickedConfig"`
 	TagCommitAsRelease   bool             `json:"isRelease"`
+	Experimental         bool             `json:"experimental"`
 }
 
 func getRelativeFilePath(filePath string) string {

--- a/internal/upload/batch_test.go
+++ b/internal/upload/batch_test.go
@@ -38,7 +38,7 @@ func TestUploadWithBadFiles(t *testing.T) {
 	clientMock.AddMockResponse(mockRes)
 	clientMock.AddMockResponse(mockRes)
 	c = clientMock
-	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, false)
+	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	err = batch.upload()
@@ -50,7 +50,7 @@ func TestUploadWithBadFiles(t *testing.T) {
 }
 
 func TestInitAnalysisWithoutAnyFiles(t *testing.T) {
-	batch := newUploadBatch(nil, file.Groups{}, nil, "CLI", 10*60, true, &DebrickedConfig{}, false)
+	batch := newUploadBatch(nil, file.Groups{}, nil, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 	err := batch.initAnalysis()
 
 	assert.ErrorContains(t, err, "failed to find dependency files")
@@ -73,7 +73,7 @@ func TestWaitWithPollingTerminatedError(t *testing.T) {
 	}
 	clientMock.AddMockResponse(mockRes)
 	c = clientMock
-	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, false)
+	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 
 	uploadResult, err := batch.wait()
 
@@ -98,7 +98,7 @@ func TestInitUploadBadFile(t *testing.T) {
 	clientMock.AddMockResponse(mockRes)
 
 	var c client.IDebClient = clientMock
-	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, false)
+	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 
 	files, err := batch.initUpload()
 
@@ -120,7 +120,7 @@ func TestInitUploadFingerprintsFree(t *testing.T) {
 	clientMock := testdata.NewDebClientMock()
 	clientMock.SetEnterpriseCustomer(false)
 	var c client.IDebClient = clientMock
-	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, false)
+	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 
 	files, err := batch.initUpload()
 
@@ -145,7 +145,7 @@ func TestInitUpload(t *testing.T) {
 	clientMock.AddMockResponse(mockRes)
 
 	var c client.IDebClient = clientMock
-	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true)
+	batch := newUploadBatch(&c, groups, metaObj, "CLI", 10*60, true, &DebrickedConfig{}, true, false)
 
 	files, err := batch.initUpload()
 

--- a/internal/upload/uploader.go
+++ b/internal/upload/uploader.go
@@ -18,6 +18,7 @@ type DebrickedOptions struct {
 	VersionHint            bool
 	DebrickedConfig        *DebrickedConfig
 	TagCommitAsRelease     bool
+	Experimental           bool
 }
 
 type IUploader interface {
@@ -47,6 +48,7 @@ func (uploader *Uploader) Upload(o IOptions) (*UploadResult, error) {
 		dOptions.VersionHint,
 		dOptions.DebrickedConfig,
 		dOptions.TagCommitAsRelease,
+		dOptions.Experimental,
 	)
 
 	err := batch.upload()


### PR DESCRIPTION
File Fingerprinting C/C++: Add flag to include repository matches