### PR TITLE
Activate auth command

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/debricked/cli/internal/client"
 	"github.com/golang-jwt/jwt"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
@@ -50,7 +49,7 @@ func (dsc DebrickedSecretClient) Delete(service string) error {
 	return keyring.Delete(service, dsc.User)
 }
 
-func NewDebrickedAuthenticator(client client.IDebClient) Authenticator {
+func NewDebrickedAuthenticator(host string) Authenticator {
 	return Authenticator{
 		SecretClient: DebrickedSecretClient{
 			User: "DebrickedCLI",
@@ -59,8 +58,8 @@ func NewDebrickedAuthenticator(client client.IDebClient) Authenticator {
 			ClientID:     "01919462-7d6e-78e8-aa24-ba779213c90f",
 			ClientSecret: "",
 			Endpoint: oauth2.Endpoint{
-				AuthURL:  client.Host() + "/app/oauth/authorize",
-				TokenURL: client.Host() + "/app/oauth/token",
+				AuthURL:  host + "/app/oauth/authorize",
+				TokenURL: host + "/app/oauth/token",
 			},
 			RedirectURL: "http://localhost:9096/callback",
 			Scopes:      []string{"select", "profile", "basicRepo", "fullApi"},

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/debricked/cli/internal/auth/testdata"
-	clientTestdata "github.com/debricked/cli/internal/client/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
@@ -15,7 +14,7 @@ const windowsOS = "windows"
 const macOS = "darwin"
 
 func TestNewAuthenticator(t *testing.T) {
-	res := NewDebrickedAuthenticator(clientTestdata.NewDebClientMock())
+	res := NewDebrickedAuthenticator("")
 	assert.NotNil(t, res)
 }
 

--- a/internal/client/deb_client.go
+++ b/internal/client/deb_client.go
@@ -42,7 +42,6 @@ func NewDebClient(accessToken *string, httpClient IClient) *DebClient {
 		host = DefaultDebrickedUri
 	}
 	authenticator := auth.NewDebrickedAuthenticator(host)
-
 	return &DebClient{
 		host:          &host,
 		httpClient:    httpClient,

--- a/internal/client/deb_client.go
+++ b/internal/client/deb_client.go
@@ -41,13 +41,13 @@ func NewDebClient(accessToken *string, httpClient IClient) *DebClient {
 	if len(host) == 0 {
 		host = DefaultDebrickedUri
 	}
-	authenticator := auth.NewDebrickedAuthenticator(host)
+
 	return &DebClient{
 		host:          &host,
 		httpClient:    httpClient,
-		accessToken:   initAccessToken(accessToken),
+		accessToken:   accessToken,
 		jwtToken:      "",
-		authenticator: authenticator,
+		authenticator: auth.NewDebrickedAuthenticator(host),
 	}
 }
 
@@ -68,25 +68,11 @@ func (debClient *DebClient) Get(uri string, format string) (*http.Response, erro
 }
 
 func (debClient *DebClient) SetAccessToken(accessToken *string) {
-	debClient.accessToken = initAccessToken(accessToken)
+	debClient.accessToken = accessToken
 }
 
 func (debClient *DebClient) Authenticator() auth.IAuthenticator {
 	return debClient.authenticator
-}
-
-func initAccessToken(accessToken *string) *string {
-	if accessToken == nil {
-		accessToken = new(string)
-	}
-	if len(*accessToken) == 0 {
-		ok := false
-		*accessToken, ok = os.LookupEnv("DEBRICKED_TOKEN")
-		if !ok {
-			accessToken = nil
-		}
-	}
-	return accessToken
 }
 
 type BillingPlan struct {

--- a/internal/client/deb_client.go
+++ b/internal/client/deb_client.go
@@ -81,13 +81,12 @@ func initAccessToken(accessToken *string) *string {
 		accessToken = new(string)
 	}
 	if len(*accessToken) == 0 {
-		*accessToken = os.Getenv("DEBRICKED_TOKEN")
+		ok := false
+		*accessToken, ok = os.LookupEnv("DEBRICKED_TOKEN")
+		if !ok {
+			accessToken = nil
+		}
 	}
-
-	if len(*accessToken) == 0 {
-		return nil
-	}
-
 	return accessToken
 }
 

--- a/internal/client/deb_client_test.go
+++ b/internal/client/deb_client_test.go
@@ -214,7 +214,25 @@ func TestAuthenticateCachedToken(t *testing.T) {
 		jwtToken:      "",
 		authenticator: testdataAuth.MockAuthenticator{},
 	}
-	err := client.authenticate()
+
+	oldEnvValue, ok := os.LookupEnv(debrickedTknEnvVar)
+	err := os.Unsetenv(debrickedTknEnvVar)
+	if err != nil {
+		t.Fatalf("failed to set env var %s", debrickedTknEnvVar)
+	}
+	defer func(key, value string, ok bool) {
+		var err error = nil
+		if ok {
+			err = os.Setenv(key, value)
+		} else {
+			err = os.Unsetenv(key)
+		}
+		if err != nil {
+			t.Fatalf("failed to reset env var %s", debrickedTknEnvVar)
+		}
+	}(debrickedTknEnvVar, oldEnvValue, ok)
+
+	err = client.authenticate()
 	if err != nil {
 		t.Fatal("failed to assert that no error occurred")
 	}

--- a/internal/client/deb_client_test.go
+++ b/internal/client/deb_client_test.go
@@ -36,37 +36,6 @@ func TestNewDebClientWithNilToken(t *testing.T) {
 	}
 }
 
-const debrickedTknEnvVar = "DEBRICKED_TOKEN"
-
-func TestNewDebClientWithTokenEnvVariable(t *testing.T) {
-	envVarTkn := "env-tkn"
-	oldEnvValue, ok := os.LookupEnv(debrickedTknEnvVar)
-	err := os.Setenv(debrickedTknEnvVar, "env-tkn")
-	if err != nil {
-		t.Fatalf("failed to set env var %s", debrickedTknEnvVar)
-	}
-	defer func(key, value string, ok bool) {
-		var err error = nil
-		if ok {
-			err = os.Setenv(key, value)
-		} else {
-			err = os.Unsetenv(key)
-		}
-		if err != nil {
-			t.Fatalf("failed to reset env var %s", debrickedTknEnvVar)
-		}
-	}(debrickedTknEnvVar, oldEnvValue, ok)
-
-	accessToken := ""
-	debClient := NewDebClient(&accessToken, nil)
-	if *debClient.host != DefaultDebrickedUri {
-		t.Error("failed to assert that host was set properly")
-	}
-	if *debClient.accessToken != envVarTkn {
-		t.Errorf("failed to assert that access token was set to %s. Got %s", envVarTkn, *debClient.accessToken)
-	}
-}
-
 func TestNewDebClientWithWithURI(t *testing.T) {
 	accessToken := ""
 	os.Setenv("DEBRICKED_URI", "https://subdomain.debricked.com")
@@ -215,24 +184,7 @@ func TestAuthenticateCachedToken(t *testing.T) {
 		authenticator: testdataAuth.MockAuthenticator{},
 	}
 
-	oldEnvValue, ok := os.LookupEnv(debrickedTknEnvVar)
-	err := os.Unsetenv(debrickedTknEnvVar)
-	if err != nil {
-		t.Fatalf("failed to set env var %s", debrickedTknEnvVar)
-	}
-	defer func(key, value string, ok bool) {
-		var err error = nil
-		if ok {
-			err = os.Setenv(key, value)
-		} else {
-			err = os.Unsetenv(key)
-		}
-		if err != nil {
-			t.Fatalf("failed to reset env var %s", debrickedTknEnvVar)
-		}
-	}(debrickedTknEnvVar, oldEnvValue, ok)
-
-	err = client.authenticate()
+	err := client.authenticate()
 	if err != nil {
 		t.Fatal("failed to assert that no error occurred")
 	}

--- a/internal/client/deb_client_test.go
+++ b/internal/client/deb_client_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	testdataAuth "github.com/debricked/cli/internal/auth/testdata"
 	testdataClient "github.com/debricked/cli/internal/client/testdata/client"
 	"github.com/stretchr/testify/assert"
 )
@@ -206,6 +207,13 @@ func TestAuthenticateExplicitToken(t *testing.T) {
 func TestAuthenticateCachedToken(t *testing.T) {
 	clientMock := testdataClient.NewMock()
 	client = NewDebClient(nil, clientMock)
+	client = &DebClient{
+		host:          nil,
+		accessToken:   nil,
+		httpClient:    clientMock,
+		jwtToken:      "",
+		authenticator: testdataAuth.MockAuthenticator{},
+	}
 	err := client.authenticate()
 	if err != nil {
 		t.Fatal("failed to assert that no error occurred")

--- a/internal/client/deb_client_test.go
+++ b/internal/client/deb_client_test.go
@@ -39,17 +39,22 @@ const debrickedTknEnvVar = "DEBRICKED_TOKEN"
 
 func TestNewDebClientWithTokenEnvVariable(t *testing.T) {
 	envVarTkn := "env-tkn"
-	oldEnvValue := os.Getenv(debrickedTknEnvVar)
+	oldEnvValue, ok := os.LookupEnv(debrickedTknEnvVar)
 	err := os.Setenv(debrickedTknEnvVar, "env-tkn")
 	if err != nil {
 		t.Fatalf("failed to set env var %s", debrickedTknEnvVar)
 	}
-	defer func(key, value string) {
-		err := os.Setenv(key, value)
+	defer func(key, value string, ok bool) {
+		var err error = nil
+		if ok {
+			err = os.Setenv(key, value)
+		} else {
+			err = os.Unsetenv(key)
+		}
 		if err != nil {
 			t.Fatalf("failed to reset env var %s", debrickedTknEnvVar)
 		}
-	}(debrickedTknEnvVar, oldEnvValue)
+	}(debrickedTknEnvVar, oldEnvValue, ok)
 
 	accessToken := ""
 	debClient := NewDebClient(&accessToken, nil)

--- a/internal/client/deb_client_test.go
+++ b/internal/client/deb_client_test.go
@@ -33,9 +33,6 @@ func TestNewDebClientWithNilToken(t *testing.T) {
 	if *debClient.host != DefaultDebrickedUri {
 		t.Error("failed to assert that host was set properly")
 	}
-	if debClient.accessToken == nil {
-		t.Error("failed to assert that access token was set properly")
-	}
 }
 
 const debrickedTknEnvVar = "DEBRICKED_TOKEN"
@@ -93,6 +90,16 @@ func TestClientUnauthorized(t *testing.T) {
 	if !strings.Contains(err.Error(), "Unauthorized. Specify access token") {
 		t.Error("Failed to assert unauthorized error message")
 	}
+}
+
+func TestHost(t *testing.T) {
+	debClient := NewDebClient(&tkn, nil)
+	assert.Equal(t, *debClient.host, debClient.Host())
+}
+
+func TestAuthenticator(t *testing.T) {
+	debClient := NewDebClient(&tkn, nil)
+	assert.NotNil(t, debClient.Authenticator())
 }
 
 func TestGet(t *testing.T) {
@@ -172,7 +179,7 @@ func TestPostWithTimeout(t *testing.T) {
 	}
 }
 
-func TestAuthenticate(t *testing.T) {
+func TestAuthenticateExplicitToken(t *testing.T) {
 	tkn = "0501ac404fd1823d0d4c047f957637a912d3b94713ee32a6"
 	jwtTkn := "jwt-tkn"
 	clientMock := testdataClient.NewMock()
@@ -188,6 +195,15 @@ func TestAuthenticate(t *testing.T) {
 	}
 	if !strings.EqualFold(jwtTkn, client.jwtToken) {
 		t.Errorf("failed to assert that the jwt token was properly set to %s. Got %s", jwtTkn, client.jwtToken)
+	}
+}
+
+func TestAuthenticateCachedToken(t *testing.T) {
+	clientMock := testdataClient.NewMock()
+	client = NewDebClient(nil, clientMock)
+	err := client.authenticate()
+	if err != nil {
+		t.Fatal("failed to assert that no error occurred")
 	}
 }
 

--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -117,9 +117,10 @@ type errorMessage struct {
 }
 
 func (debClient *DebClient) authenticate() error {
-
-	if debClient.accessToken != nil {
-		return debClient.authenticateExplicitToken()
+	if debClient.accessToken != nil { // To avoid segfault
+		if len(*debClient.accessToken) != 0 {
+			return debClient.authenticateExplicitToken()
+		}
 	}
 
 	return debClient.authenticateCachedToken()

--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -117,6 +117,24 @@ type errorMessage struct {
 }
 
 func (debClient *DebClient) authenticate() error {
+
+	if debClient.accessToken != nil {
+		return debClient.authenticateExplicitToken()
+	}
+
+	return debClient.authenticateCachedToken()
+}
+
+func (debClient *DebClient) authenticateCachedToken() error {
+	token, err := debClient.authenticator.Token()
+	if err == nil {
+		debClient.jwtToken = token.AccessToken
+	}
+
+	return err
+}
+
+func (debClient *DebClient) authenticateExplicitToken() error {
 	uri := "/api/login_refresh"
 
 	data := map[string]string{"refresh_token": *debClient.accessToken}

--- a/internal/client/testdata/deb_client_mock.go
+++ b/internal/client/testdata/deb_client_mock.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/debricked/cli/internal/auth"
+	authTestdata "github.com/debricked/cli/internal/auth/testdata"
 	"github.com/debricked/cli/internal/client"
 )
 
@@ -145,4 +147,11 @@ func (mock *DebClientMock) SetEnterpriseCustomer(isEnterprise bool) {
 func (mock *DebClientMock) IsEnterpriseCustomer(silent bool) bool {
 
 	return mock.isEnterprise
+}
+
+func (mock *DebClientMock) Authenticator() auth.IAuthenticator {
+	return auth.Authenticator{
+		SecretClient: authTestdata.MockInvalidSecretClient{},
+		OAuthConfig:  nil,
+	}
 }

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -4,14 +4,11 @@ import (
 	"testing"
 
 	"github.com/debricked/cli/internal/auth"
-	"github.com/debricked/cli/internal/client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewAuthCmd(t *testing.T) {
-	token := "token"
-	deb_client := client.NewDebClient(&token, nil)
-	authenticator := auth.NewDebrickedAuthenticator(deb_client)
+	authenticator := auth.NewDebrickedAuthenticator("")
 	cmd := NewAuthCmd(authenticator)
 	commands := cmd.Commands()
 	nbrOfCommands := 3

--- a/internal/cmd/auth/login/login_test.go
+++ b/internal/cmd/auth/login/login_test.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/debricked/cli/internal/auth"
 	"github.com/debricked/cli/internal/auth/testdata"
-	"github.com/debricked/cli/internal/client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewLoginCmd(t *testing.T) {
-	token := "token"
-	deb_client := client.NewDebClient(&token, nil)
-	authenticator := auth.NewDebrickedAuthenticator(deb_client)
+	authenticator := auth.NewDebrickedAuthenticator("")
 	cmd := NewLoginCmd(authenticator)
 	commands := cmd.Commands()
 	nbrOfCommands := 0

--- a/internal/cmd/auth/logout/logout_test.go
+++ b/internal/cmd/auth/logout/logout_test.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/debricked/cli/internal/auth"
 	"github.com/debricked/cli/internal/auth/testdata"
-	"github.com/debricked/cli/internal/client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewLogoutCmd(t *testing.T) {
-	token := "token"
-	deb_client := client.NewDebClient(&token, nil)
-	authenticator := auth.NewDebrickedAuthenticator(deb_client)
+	authenticator := auth.NewDebrickedAuthenticator("")
 	cmd := NewLogoutCmd(authenticator)
 	commands := cmd.Commands()
 	nbrOfCommands := 0

--- a/internal/cmd/auth/token/token_test.go
+++ b/internal/cmd/auth/token/token_test.go
@@ -5,15 +5,12 @@ import (
 
 	"github.com/debricked/cli/internal/auth"
 	"github.com/debricked/cli/internal/auth/testdata"
-	"github.com/debricked/cli/internal/client"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTokenCmd(t *testing.T) {
-	token := "token"
-	deb_client := client.NewDebClient(&token, nil)
-	authenticator := auth.NewDebrickedAuthenticator(deb_client)
+	authenticator := auth.NewDebrickedAuthenticator("")
 	cmd := NewTokenCmd(authenticator)
 	commands := cmd.Commands()
 	nbrOfCommands := 0
@@ -50,6 +47,16 @@ func TestPreRun(t *testing.T) {
 
 func TestRunE(t *testing.T) {
 	a := testdata.MockAuthenticator{}
+	runE := RunE(a)
+
+	err := runE(nil, []string{})
+
+	assert.NoError(t, err)
+}
+
+func TestRunEJSONFlag(t *testing.T) {
+	a := testdata.MockAuthenticator{}
+	jsonFormat = true
 	runE := RunE(a)
 
 	err := runE(nil, []string{})

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -15,7 +15,8 @@ import (
 
 var accessToken string
 
-const AccessTokenFlag = "access-token"
+const AccessTokenFlag = "token"
+const OldAccessTokenFlag = "access-token"
 
 func NewRootCmd(version string, container *wire.CliContainer) *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -29,12 +30,14 @@ Complete documentation is available at https://docs.debricked.com/tools-and-inte
 		Version: version,
 	}
 	viper.SetEnvPrefix("DEBRICKED")
+	viper.AutomaticEnv()
 	viper.MustBindEnv(AccessTokenFlag)
+
 	rootCmd.PersistentFlags().StringVarP(
 		&accessToken,
-		AccessTokenFlag,
+		OldAccessTokenFlag,
 		"t",
-		"",
+		viper.GetString(AccessTokenFlag),
 		`Debricked access token. 
 Read more: https://docs.debricked.com/product/administration/generate-access-token`,
 	)

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -21,7 +21,7 @@ func TestNewRootCmd(t *testing.T) {
 	}
 
 	flags := cmd.PersistentFlags()
-	flag := flags.Lookup(AccessTokenFlag)
+	flag := flags.Lookup(OldAccessTokenFlag)
 	assert.NotNil(t, flag)
 	assert.Equal(t, "t", flag.Shorthand)
 
@@ -34,7 +34,7 @@ func TestNewRootCmd(t *testing.T) {
 			break
 		}
 	}
-	assert.Truef(t, match, "failed to assert that flag was present: "+AccessTokenFlag)
+	assert.Truef(t, match, "failed to assert that flag was present: "+OldAccessTokenFlag)
 	assert.Len(t, viperKeys, 22)
 }
 

--- a/internal/file/finder_test.go
+++ b/internal/file/finder_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/debricked/cli/internal/auth"
 	"github.com/debricked/cli/internal/client/testdata"
 	ioFs "github.com/debricked/cli/internal/io"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,10 @@ func (mock *debClientMock) ConfigureClientSettings(retry bool, timeout int) {}
 
 func (mock *debClientMock) IsEnterpriseCustomer(silent bool) bool {
 	return true
+}
+
+func (mock *debClientMock) Authenticator() auth.IAuthenticator {
+	return nil
 }
 
 var finder *Finder

--- a/internal/upload/uploader_test.go
+++ b/internal/upload/uploader_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/debricked/cli/internal/auth"
 	"github.com/debricked/cli/internal/client"
 	"github.com/debricked/cli/internal/client/testdata"
 	"github.com/debricked/cli/internal/file"
@@ -158,4 +159,8 @@ func (mock *debClientMock) SetAccessToken(_ *string) {}
 
 func (mock *debClientMock) IsEnterpriseCustomer(silent bool) bool {
 	return true
+}
+
+func (mock *debClientMock) Authenticator() auth.IAuthenticator {
+	return nil
 }

--- a/internal/wire/cli_container.go
+++ b/internal/wire/cli_container.go
@@ -94,7 +94,7 @@ func (cc *CliContainer) wire() error {
 	cc.licenseReporter = licenseReport.Reporter{DebClient: cc.debClient}
 	cc.vulnerabilityReporter = vulnerabilityReport.Reporter{DebClient: cc.debClient}
 	cc.sbomReporter = sbomReport.Reporter{DebClient: cc.debClient, FileWriter: io.FileWriter{}}
-	cc.authenticator = auth.NewDebrickedAuthenticator(cc.debClient)
+	cc.authenticator = cc.debClient.Authenticator()
 
 	return nil
 }

--- a/internal/wire/cli_container_test.go
+++ b/internal/wire/cli_container_test.go
@@ -40,4 +40,6 @@ func assertCliContainer(t *testing.T, cc *CliContainer) {
 	assert.NotNil(t, cc.LicenseReporter())
 	assert.NotNil(t, cc.VulnerabilityReporter())
 	assert.NotNil(t, cc.Fingerprinter())
+	assert.NotNil(t, cc.Authenticator())
+	assert.NotNil(t, cc.SBOMReporter())
 }


### PR DESCRIPTION
The client interacting with debricked can now utilise the credentials saved using the auth command. 