### PR TITLE
rename report to export.

### DIFF
--- a/internal/cmd/report/license/license.go
+++ b/internal/cmd/report/license/license.go
@@ -21,17 +21,17 @@ const (
 func NewLicenseCmd(reporter report.IReporter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "license",
-		Short: "Generate license report",
-		Long: `Generate license report from a commit hash. 
+		Short: "Generate license export",
+		Long: `Generate license export from a commit hash. 
 This is a premium feature. Please visit https://debricked.com/pricing/ for more info.
-The finished report will be sent to the specified email address.`,
+The finished export will be sent to the specified email address.`,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlags(cmd.Flags())
 		},
 		RunE: RunE(reporter),
 	}
 
-	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the report will be sent to")
+	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the export will be sent to")
 	viper.MustBindEnv(EmailFlag)
 
 	cmd.Flags().StringVarP(&commitHash, CommitFlag, "c", "", "commit hash")
@@ -51,7 +51,7 @@ func RunE(r report.IReporter) func(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("%s %s\n", color.RedString("⨯"), err.Error())
 		}
 
-		fmt.Printf("%s Successfully ordered license report\n", color.GreenString("✔"))
+		fmt.Printf("%s Successfully ordered license export\n", color.GreenString("✔"))
 
 		return nil
 	}

--- a/internal/cmd/report/report.go
+++ b/internal/cmd/report/report.go
@@ -17,10 +17,10 @@ func NewReportCmd(
 	sbomReporter sbomReport.Reporter,
 ) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "report",
-		Short: "Generate reports",
-		Long: `Generate reports.
-Premium is required for license and vulnerability reports. Enterprise is required for SBOM reports. Please visit https://debricked.com/pricing/ for more info.`,
+		Use:   "export",
+		Short: "Generate exports for vulnerabilities, licenses, and SBOM.",
+		Long: `Generate exports.
+Premium is required for license and vulnerability exports. Enterprise is required for SBOM exports. Please visit https://debricked.com/pricing/ for more info.`,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlags(cmd.Flags())
 		},

--- a/internal/cmd/report/sbom/sbom.go
+++ b/internal/cmd/report/sbom/sbom.go
@@ -30,8 +30,8 @@ const FormatFlag = "format"
 func NewSBOMCmd(reporter report.IReporter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sbom",
-		Short: "Generate SBOM report",
-		Long: `Generate SBOM report for chosen commit and repository. 
+		Short: "Generate SBOM export",
+		Long: `Generate SBOM export for chosen commit and repository. 
 For an example of the SBOM format see https://github.com/debricked/blog-snippets/blob/main/example-sbom-report/SBOM_2022-12-14.json.
 
 This is an enterprise feature. Please visit https://debricked.com/pricing/ for more info.`,
@@ -41,18 +41,18 @@ This is an enterprise feature. Please visit https://debricked.com/pricing/ for m
 		RunE: RunE(reporter),
 	}
 
-	cmd.Flags().StringVarP(&commitId, CommitFlag, "c", "", "The commit that you want an SBOM report for")
+	cmd.Flags().StringVarP(&commitId, CommitFlag, "c", "", "The commit that you want an SBOM export for")
 	_ = cmd.MarkFlagRequired(CommitFlag)
 	viper.MustBindEnv(CommitFlag)
 
-	cmd.Flags().StringVarP(&repositoryId, RepositorylFlag, "r", "", "The repository that you want an SBOM report for")
+	cmd.Flags().StringVarP(&repositoryId, RepositorylFlag, "r", "", "The repository that you want an SBOM export for")
 	_ = cmd.MarkFlagRequired(RepositorylFlag)
 	viper.MustBindEnv(RepositorylFlag)
 
-	cmd.Flags().StringVarP(&branch, BranchFlag, "b", "", "The branch that you want an SBOM report for")
+	cmd.Flags().StringVarP(&branch, BranchFlag, "b", "", "The branch that you want an SBOM export for")
 	viper.MustBindEnv(BranchFlag)
 
-	cmd.Flags().StringVarP(&format, FormatFlag, "f", "", `The format that you want the SBOM report in.
+	cmd.Flags().StringVarP(&format, FormatFlag, "f", "", `The format that you want the SBOM export in.
 
 Supported options are: 'CycloneDX', 'SPDX'`,
 	)

--- a/internal/cmd/report/vulnerability/vulnerability.go
+++ b/internal/cmd/report/vulnerability/vulnerability.go
@@ -17,17 +17,17 @@ const EmailFlag = "email"
 func NewVulnerabilityCmd(reporter report.IReporter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vulnerability",
-		Short: "Generate vulnerability report",
-		Long: `Generate vulnerability report for all your repositories. 
+		Short: "Generate vulnerability export",
+		Long: `Generate vulnerability export for all your repositories. 
 This is a premium feature. Please visit https://debricked.com/pricing/ for more info.
-The finished report will be sent to the specified email address.`,
+The finished export will be sent to the specified email address.`,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlags(cmd.Flags())
 		},
 		RunE: RunE(reporter),
 	}
 
-	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the report will be sent to")
+	cmd.Flags().StringVarP(&email, EmailFlag, "e", "", "The email address that the export will be sent to")
 	_ = cmd.MarkFlagRequired(EmailFlag)
 	viper.MustBindEnv(EmailFlag)
 
@@ -41,7 +41,7 @@ func RunE(r report.IReporter) func(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("%s %s\n", color.RedString("⨯"), err.Error())
 		}
 
-		fmt.Printf("%s Successfully ordered vulnerability report\n", color.GreenString("✔"))
+		fmt.Printf("%s Successfully ordered vulnerability export\n", color.GreenString("✔"))
 
 		return nil
 	}


### PR DESCRIPTION
Rename report to export. Only changes user-facing code, rather than all internal mentions of report.