### PR TITLE
Fix debian bookworm

### DIFF
--- a/build/docker/debian.Dockerfile
+++ b/build/docker/debian.Dockerfile
@@ -96,8 +96,15 @@ RUN curl -fsSLO https://dot.net/v1/dotnet-install.sh \
     && rm ./dotnet-install.sh \
     && dotnet help
 
+# Prevent systemd from being configured to avoid QEMU segfaults on arm64
+RUN echo 'exit 101' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
+
 RUN apt -y update && apt -y install ca-certificates && \
-    apt -y -o Dpkg::Options::="--force-overwrite" install -t unstable \
+    apt-mark hold systemd && \
+    apt -y -o Dpkg::Options::="--force-overwrite" \
+          -o Dpkg::Options::="--force-confold" \
+          -o Dpkg::Options::="--force-confdef" \
+          install -t unstable --no-install-recommends \
     python3.13 \
     python3.13-venv \
     python3-pip \

--- a/build/docker/debian.Dockerfile
+++ b/build/docker/debian.Dockerfile
@@ -96,7 +96,7 @@ RUN curl -fsSLO https://dot.net/v1/dotnet-install.sh \
     && rm ./dotnet-install.sh \
     && dotnet help
 
-RUN apt -y update && apt -y upgrade && apt -y install ca-certificates && \
+RUN apt -y update && apt -y install ca-certificates && \
     apt -y -o Dpkg::Options::="--force-overwrite" install -t unstable \
     python3.13 \
     python3.13-venv \

--- a/build/docker/debian.Dockerfile
+++ b/build/docker/debian.Dockerfile
@@ -97,7 +97,7 @@ RUN curl -fsSLO https://dot.net/v1/dotnet-install.sh \
     && dotnet help
 
 RUN apt -y update && apt -y upgrade && apt -y install ca-certificates && \
-    apt -y install -t unstable \
+    apt -y -o Dpkg::Options::="--force-overwrite" install -t unstable \
     python3.13 \
     python3.13-venv \
     python3-pip \


### PR DESCRIPTION
The base image uses Debian bookworm's libssl3 (3.0.x), but installing packages from unstable pulls in openssl-provider-legacy (3.6.x) which ships the same file. The --force-overwrite flag resolves this conflict safely since the newer version supersedes the old one.